### PR TITLE
in some situations, allow 4 possible hints for some players

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -306,6 +306,14 @@ impl CardPossibilityTable {
             .collect::<HashSet<_>>()
             .len() == 1
     }
+
+    pub fn can_be_color(&self, color: Color) -> bool {
+        self.get_possibilities().into_iter().any(|card| card.color == color)
+    }
+
+    pub fn can_be_value(&self, value: Value) -> bool {
+        self.get_possibilities().into_iter().any(|card| card.value == value)
+    }
 }
 impl <'a> From<&'a CardCounts> for CardPossibilityTable {
     fn from(counts: &'a CardCounts) -> CardPossibilityTable {


### PR DESCRIPTION
In particular, do this when for a player when it is public knowledge
that they have at least 2 distinct numbers and 2 distinct colors

Before

```
19: 1
20: 1
21: 4
22: 14
23: 32
24: 216
25: 1732
INFO - Example seed with non-perfect score: 1044968192
INFO - Percentage perfect: 86.6%
INFO - Average score: 24.8255
INFO - Average lives: 2.828
```

After:

```
18: 1
19: 2
20: 1
21: 9
22: 11
23: 24
24: 211
25: 1741
INFO - Example seed with non-perfect score: 46904532
INFO - Percentage perfect: 87.05%
INFO - Average score: 24.824
INFO - Average lives: 2.8115
```

So I guess it's a teeny improvement ¯\_(ツ)_/¯ 

(Also this is my first time writing Rust so let me know if I could have done anything better.)
